### PR TITLE
iteritems does not exist in python 3 so use items() instead of iterite…

### DIFF
--- a/protractor/test.py
+++ b/protractor/test.py
@@ -34,7 +34,7 @@ class ProtractorTestCaseMixin(object):
             protractor_command += ' --specs {}'.format(','.join(self.specs))
         if self.suite:
             protractor_command += ' --suite {}'.format(self.suite)
-        for key, value in self.get_protractor_params().iteritems():
+        for key, value in self.get_protractor_params().items():
             protractor_command += ' --params.{key}={value}'.format(
                 key=key, value=value
             )


### PR DESCRIPTION
…ms().

Signed-off-by: David Black dblack@atlassian.com
