### PR TITLE
Live server param

### DIFF
--- a/protractor/management/commands/protractor.py
+++ b/protractor/management/commands/protractor.py
@@ -71,11 +71,24 @@ class Command(BaseCommand):
         test_server_process.daemon = True
         test_server_process.start()
 
+        authority = options['addrport']
+        if ':' not in authority:
+            authority = 'localhost:' + authority
+        live_server_url = 'http://%s/' % authority
+
+        params = {
+            'live_server_url': live_server_url
+        }
+
         protractor_command = 'protractor {}'.format(options['protractor_conf'])
         if options['specs']:
             protractor_command += '--specs {}'.format(options['specs'])
         if options['suite']:
             protractor_command += '--suite {}'.format(options['suite'])
+        for key, value in params.items():
+            protractor_command += ' --params.{key}={value}'.format(
+                key=key, value=value
+            )
 
         return_code = subprocess.call(protractor_command.split())
         self.teardown_databases(old_config, options)

--- a/protractor/management/commands/protractor.py
+++ b/protractor/management/commands/protractor.py
@@ -82,9 +82,9 @@ class Command(BaseCommand):
 
         protractor_command = 'protractor {}'.format(options['protractor_conf'])
         if options['specs']:
-            protractor_command += '--specs {}'.format(options['specs'])
+            protractor_command += ' --specs {}'.format(options['specs'])
         if options['suite']:
-            protractor_command += '--suite {}'.format(options['suite'])
+            protractor_command += ' --suite {}'.format(options['suite'])
         for key, value in params.items():
             protractor_command += ' --params.{key}={value}'.format(
                 key=key, value=value

--- a/protractor/management/commands/protractor.py
+++ b/protractor/management/commands/protractor.py
@@ -81,6 +81,7 @@ class Command(BaseCommand):
         }
 
         protractor_command = 'protractor {}'.format(options['protractor_conf'])
+        protractor_command += ' --baseUrl {}'.format(live_server_url)
         if options['specs']:
             protractor_command += ' --specs {}'.format(options['specs'])
         if options['suite']:

--- a/protractor/test.py
+++ b/protractor/test.py
@@ -30,6 +30,7 @@ class ProtractorTestCaseMixin(object):
 
     def test_run(self):
         protractor_command = 'protractor {}'.format(self.protractor_conf)
+        protractor_command += ' --baseUrl {}'.format(self.live_server_url)
         if self.specs:
             protractor_command += ' --specs {}'.format(','.join(self.specs))
         if self.suite:


### PR DESCRIPTION
Automatically provide the correct server URL to protractor tests from the django protractor command. This also fixes a bug when using the --suite and --specs options to protractor.
