### PR TITLE
Added support for configuring address via environment variable

### DIFF
--- a/protractor/management/commands/protractor.py
+++ b/protractor/management/commands/protractor.py
@@ -46,7 +46,7 @@ class Command(BaseCommand):
             help='Specify fixture to load initial data to the database'
         ),
         make_option('--addrport', action='store', dest='addrport',
-            type='string', default='8081',
+            type='string',
             help='port number or ipaddr:port to run the server on'),
     )
 
@@ -65,6 +65,10 @@ class Command(BaseCommand):
         if fixtures:
             call_command('loaddata', *fixtures,
                          **{'verbosity': options['verbosity']})
+
+        if options['addrport'] is None:
+            options['addrport'] = os.environ.get(
+                    'DJANGO_LIVE_TEST_SERVER_ADDRESS', '8081')
 
         test_server_process = Process(target=self.runserver, args=(options,))
         test_server_process.daemon = True

--- a/protractor/management/commands/protractor.py
+++ b/protractor/management/commands/protractor.py
@@ -73,7 +73,7 @@ class Command(BaseCommand):
         authority = options['addrport']
         if ':' not in authority:
             authority = 'localhost:' + authority
-        live_server_url = 'http://%s/' % authority
+        live_server_url = 'http://%s' % authority
 
         params = {
             'live_server_url': live_server_url


### PR DESCRIPTION
This adds support for the DJANGO_LIVE_TEST_SERVER_ADDRESS environment variable used by the LiveServerTestCast in stock Django. The does not support multiple ports like the stock Django syntax, but it will pick it up for a single port which is probably the most common case. The environment variable only needs to be set once then for both styles of testing.

This also fixes a minor issue with a previous pull request where a slash was added to the URL given. This deviates from the live_server_url that stock Django provides and can break code relying on it.
