### PR TITLE
Add npm-prefix for locally installed protractor.

### DIFF
--- a/protractor/management/commands/protractor.py
+++ b/protractor/management/commands/protractor.py
@@ -52,7 +52,7 @@ class Command(BaseCommand):
             help='Specify if direct connect is enabled (do not spawn a webdriver)'),
         make_option('--npm-prefix', action='store', dest='npm_prefix',
             type='string',
-            help='If protractor is installed locally, provide the path to the node_modules'),
+            help='If protractor is installed locally, provide the path to the node_modules folder'),
     )
 
     def handle(self, *args, **options):

--- a/protractor/test.py
+++ b/protractor/test.py
@@ -3,9 +3,9 @@
 import os
 import subprocess
 
-
 class ProtractorTestCaseMixin(object):
     protractor_conf = 'protractor.conf.js'
+    npm_prefix = None
     suite = None
     specs = None
 
@@ -29,7 +29,13 @@ class ProtractorTestCaseMixin(object):
         }
 
     def test_run(self):
-        protractor_command = 'protractor {}'.format(self.protractor_conf)
+        command_prefix = ''
+        npm_prefix = self.npm_prefix
+        if (npm_prefix):
+            npm_prefix = 'npm run --prefix={} '.format(npm_prefix)
+        protractor_command = npm_prefix + 'protractor ' + os.getcwd() + '/{}'.format(self.protractor_conf)
+        if (npm_prefix):
+            protractor_command += ' -- '
         protractor_command += ' --baseUrl {}'.format(self.live_server_url)
         if self.specs:
             protractor_command += ' --specs {}'.format(','.join(self.specs))

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-protractor',
-    version='0.8.4',
+    version='0.8.5',
     packages=find_packages(),
     include_package_data=True,
     install_requires=['django>=1.4'],


### PR DESCRIPTION
In order to allow to use this package with a locally installed protractor package, added the --npm-prefix option.